### PR TITLE
Fixed error in readme example.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Usage
 
     XBTUSD = Instrument(symbol='XBTUSD',
                         channels=channels)
-    XBTUSD.on('action', lambda msg: print(message))
+    XBTUSD.on('action', lambda msg: print(msg))
 
     XBTUSD.run_forever()
 


### PR DESCRIPTION
Example used wrong variable, which lead to crash. This change fixes it.