### PR TITLE
Fix wrongly named var: auth => auth_header

### DIFF
--- a/bitmex_websocket/_bitmex_websocket.py
+++ b/bitmex_websocket/_bitmex_websocket.py
@@ -123,7 +123,7 @@ class BitMEXWebsocket(EventEmitter, WebSocketApp):
             api_signature = generate_signature(
                 settings.BITMEX_API_SECRET, 'GET', '/realtime', nonce, '')
 
-            auth = [
+            auth_header = [
                 "api-nonce: " + str(nonce),
                 "api-signature: " + api_signature,
                 "api-key:" + settings.BITMEX_API_KEY


### PR DESCRIPTION
The whole if block is clearly meant to set auth_header with a content other than the default [], when keys are present.