### PR TITLE
Fix subclass initialization

### DIFF
--- a/bitmex_websocket/_bitmex_websocket.py
+++ b/bitmex_websocket/_bitmex_websocket.py
@@ -46,7 +46,7 @@ class BitMEXWebsocket(
             on_pong=self.on_pong,
             **kwargs
         )
-        super(EventEmitter, self).__init__()
+        EventEmitter.__init__(self)
 
         self.on('subscribe', self.on_subscribe)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
 alog
 pyee
 requests
-semver
-setuptools
 websocket-client
-wheel
 click

--- a/setup.py
+++ b/setup.py
@@ -20,13 +20,8 @@ def get_reqs_from_file(file):
     return [str(ir.req) for ir in install_requirements]
 
 
-def get_version_info():
-    version_file = open(realpath('./.version'))
-    return version_file.read()
-
-
 setup(name='bitmex_websocket',
-      version=get_version_info(),
+      version='0.2.78',
       description='Bitmex websocket API',
       long_description=open('README.rst').read().strip(),
       author='José Oliveros',

--- a/setup.py
+++ b/setup.py
@@ -3,21 +3,7 @@
 # -*- coding: utf-8 -*-
 
 from setuptools import setup
-from pip.req import parse_requirements
-from pip.download import PipSession
 from os.path import realpath
-
-
-def get_reqs_from_file(file):
-    file_path = realpath(file)
-
-    # parse_requirements() returns generator of pip.req.InstallRequirement
-    # objects
-    install_requirements = parse_requirements(file_path, session=PipSession)
-
-    # reqs is a list of requirement
-    # e.g. ['django==1.5.1', 'mezzanine==1.4.6']
-    return [str(ir.req) for ir in install_requirements]
 
 
 setup(name='bitmex_websocket',
@@ -31,9 +17,9 @@ setup(name='bitmex_websocket',
         'bitmex_websocket',
         'bitmex_websocket.auth'
       ],
-      install_requires=get_reqs_from_file('./requirements.txt'),
+      install_requires=['alog', 'pyee', 'requests', 'websocket-client' 'click'],
       include_package_data=True,
-      tests_require=get_reqs_from_file('./requirements-test.txt'),
+      tests_require=['flake8', 'mock', 'pytest', 'pytest-mock', 'pytest-cov'],
       license='MIT License',
       zip_safe=True,
       keywords='bitmex websocket bot cryptocurrency',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='bitmex_websocket',
         'bitmex_websocket',
         'bitmex_websocket.auth'
       ],
-      install_requires=['alog', 'pyee', 'requests', 'websocket-client' 'click'],
+      install_requires=['alog', 'pyee', 'requests', 'websocket-client', 'click'],
       include_package_data=True,
       tests_require=['flake8', 'mock', 'pytest', 'pytest-mock', 'pytest-cov'],
       license='MIT License',


### PR DESCRIPTION
Current way of initialization of `EventEmitter` subclass is broken and leads to a crash:
```
AttributeError: 'BitMEXWebsocket' object has no attribute '_events'
```

You can ensure that EventEmitter constructor hasn't actually called on this example:

```
class A:
    def __init__(self):
        self.aa = 1

class B:
    def __init__(self):
        self.bb = 2

class AB(A, B):
    def __init__(self):
        super().__init__()
        super(B, self).__init__()
        #B.__init__(self)

ab = AB()
print(ab.aa)
print(ab.bb)

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'AB' object has no attribute 'bb'
```
