### PR TITLE
Fix subclass initialization

### DIFF
--- a/bitmex_websocket/_bitmex_websocket.py
+++ b/bitmex_websocket/_bitmex_websocket.py
@@ -46,7 +46,7 @@ class BitMEXWebsocket(
             on_pong=self.on_pong,
             **kwargs
         )
-        super(EventEmitter, self).__init__()
+        EventEmitter.__init__(self)
 
         self.on('subscribe', self.on_subscribe)
 


### PR DESCRIPTION
Current way of initialization of `EventEmitter` subclass is broken and leads to a crash:
```
AttributeError: 'BitMEXWebsocket' object has no attribute '_events'
```

You can ensure that EventEmitter constructor hasn't actually called on this example:

```
class A:
    def __init__(self):
        self.aa = 1

class B:
    def __init__(self):
        self.bb = 2

class AB(A, B):
    def __init__(self):
        super().__init__()
        super(B, self).__init__()
        #B.__init__(self)

ab = AB()
print(ab.aa)
print(ab.bb)

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'AB' object has no attribute 'bb'
```
