### PR TITLE
Build and usage improvements

### DIFF
--- a/bitmex_websocket/_bitmex_websocket.py
+++ b/bitmex_websocket/_bitmex_websocket.py
@@ -65,18 +65,13 @@ class BitMEXWebsocket(
     def run_forever(self, **kwargs):
         """Connect to the websocket in a thread."""
 
-        # setup websocket.run_forever arguments
-        ws_run_args = {
-            'sslopt': {"cert_reqs": ssl.CERT_NONE}
-        }
-
         if self.heartbeat:
-            ws_run_args['ping_timeout'] = self.ping_timeout
-            ws_run_args['ping_interval'] = self.ping_interval
+            kwargs['ping_timeout'] = self.ping_timeout
+            kwargs['ping_interval'] = self.ping_interval
 
-        alog.debug(ws_run_args)
+        alog.debug(kwargs)
 
-        super().run_forever(**ws_run_args)
+        super().run_forever(**kwargs)
 
     def on_pong(self, message):
         timestamp = float(time.time() * 1000)

--- a/bitmex_websocket/_bitmex_websocket.py
+++ b/bitmex_websocket/_bitmex_websocket.py
@@ -73,10 +73,11 @@ class BitMEXWebsocket(
 
         super().run_forever(**kwargs)
 
-    def on_pong(self, message):
+    @staticmethod
+    def on_pong(instanse, message):
         timestamp = float(time.time() * 1000)
-        latency = timestamp - (self.last_ping_tm * 1000)
-        self.emit('latency', latency)
+        latency = timestamp - (instanse.last_ping_tm * 1000)
+        instanse.emit('latency', latency)
 
     def subscribe(self, channel: str):
         subscription_msg = {"op": "subscribe", "args": [channel]}
@@ -95,23 +96,24 @@ class BitMEXWebsocket(
         else:
             raise Exception('Unable to subsribe.')
 
-    def on_message(self, message):
+    @staticmethod
+    def on_message(instanse, message):
         """Handler for parsing WS messages."""
         message = json.loads(message)
 
         if 'error' in message:
-            self.on_error(message['error'])
+            instanse.on_error(instanse, message['error'])
 
         action = message['action'] if 'action' in message else None
 
         if action:
-            self.emit('action', message)
+            instanse.emit('action', message)
 
         elif 'subscribe' in message:
-            self.emit('subscribe', message)
+            instanse.emit('subscribe', message)
 
         elif 'status' in message:
-            self.emit('status', message)
+            instanse.emit('status', message)
 
     def header(self):
         """Return auth headers. Will use API Keys if present in settings."""
@@ -138,13 +140,15 @@ class BitMEXWebsocket(
 
         return auth_header
 
-    def on_open(self):
+    @staticmethod
+    def on_open(instanse):
         alog.debug("Websocket Opened.")
-        self.emit('open')
+        instanse.emit('open')
 
-    def on_close(self):
+    @staticmethod
+    def on_close(instanse):
         alog.info('Websocket Closed')
 
-    def on_error(self, error):
+    @staticmethod
+    def on_error(instanse, error):
         raise BitMEXWebsocketConnectionError(error)
-

--- a/bitmex_websocket/_bitmex_websocket.py
+++ b/bitmex_websocket/_bitmex_websocket.py
@@ -146,7 +146,7 @@ class BitMEXWebsocket(
         instanse.emit('open')
 
     @staticmethod
-    def on_close(instanse):
+    def on_close(instanse, *args):
         alog.info('Websocket Closed')
 
     @staticmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pyee
 requests
 semver
 setuptools
-websocket-client
+websocket-client>=1
 wheel
 click

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,6 @@ def get_reqs_from_file(file):
         return [req.strip() for req in install_requirements]
 
 
-def get_version_info():
-    version_file = open(realpath('./.version'))
-    return version_file.read()
-
-
 setup(name='bitmex_websocket',
       version=open(realpath('./.version')).read(),
       description='Bitmex websocket API',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def get_version_info():
 
 
 setup(name='bitmex_websocket',
-      version=get_version_info(),
+      version='0.2.83',
       description='Bitmex websocket API',
       long_description=open('README.rst').read().strip(),
       author='José Oliveros',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 # -*- coding: utf-8 -*-
-import alog
 from pkg_resources import parse_requirements
 from setuptools import setup
 from os.path import realpath
@@ -23,7 +22,7 @@ def get_version_info():
 
 
 setup(name='bitmex_websocket',
-      version='0.2.83',
+      version=open(realpath('./.version')).read(),
       description='Bitmex websocket API',
       long_description=open('README.rst').read().strip(),
       author='José Oliveros',


### PR DESCRIPTION
1. Enable custom arguments for websocket connection method (e.g. for proxy)
2. Remove ambiguous argument `'sslopt': {"cert_reqs": ssl.CERT_NONE}` - looks as vulnerability
3. fix setup.py for pypoetry: command `poetry add git+https://github.com/joliveros/bitmex-websocket.git` failed with reason `Unable to retrieve the package version`.
4. Bump `websocket-client` dependency: callbacks are called with extra arg: (self,) instead of () since `websocket-client==1.0`.